### PR TITLE
Add Curly45 example

### DIFF
--- a/src/examples/curly45.ts
+++ b/src/examples/curly45.ts
@@ -1,0 +1,146 @@
+import { ConfigExample } from './index';
+
+/**
+ * An example Ergogen configuration for a curly layout keyboard.
+ * @type {ConfigExample}
+ */
+const Curly45: ConfigExample = {
+  label: 'Curly-45',
+  author: 'peterjc',
+  value: `meta:
+  engine: 4.1.0
+  version: 1.0.0
+  author: peterjc
+units:
+  # targetting CFX keycaps
+  cx: 16.5
+  cy: 16.5
+  mg: 50
+points:
+  mirror:
+    ref: top_inner_sole
+    distance: 2U
+  # Using one zone per row, and starting from the inner column
+  # (negative spread, so right to left unlike the default).
+  zones:
+    top:
+      key:
+        splay: 5.5
+        origin: [0.5*U,-0.5*U]
+        spread: -U
+      columns:
+        inner:
+          key:
+           splay: -22
+        index:
+        middle:
+        ring:
+        pinky:
+        outer:
+          # Backtick on left, open bracket on right
+          key:
+           splay: 0
+        outer2:
+          # Escape on left, close bracket on right
+          key:
+           splay: 0
+        backspace:
+          key:
+           asym: right
+           splay: 0
+      rows:
+        sole.padding: 1U
+    middle:
+      anchor:
+        ref: top_inner_sole
+        shift: [0, -U]
+      key:
+        splay: 6
+        origin: [0.5*U,-0.5*U]
+        spread: -U
+      columns:
+        inner:
+          key:
+           splay: 0
+        index:
+          key:
+           splay: 6.5
+        middle:
+        ring:
+        pinky:
+          key:
+           splay: 3.5
+        tab:
+          # Tab (or maybe ctrl) on left (1.5U)
+          key:
+            asym: left
+            splay: 0
+            width: 1.5*u
+            # Adjust as wide key:
+            spread: -1.27*U
+        quote:
+          # Quote on right
+          key:
+           asym: right
+           splay: 0
+           # avoid dead space from ghost tab
+           spread: 0.27*U
+        enter:
+          # Enter (or maybe backslash/pipe) on right (1.5U)
+          key:
+           asym: right
+           splay: 0
+           width: 1.5*u
+           spread: -1.27*U
+      rows:
+        sole.padding: 1U
+    bottom:
+      anchor:
+        ref: middle_inner_sole
+        shift: [0, -U]
+      key:
+        splay: 7
+        origin: [0.5*U,-0.5*U]
+        spread: -U
+      columns:
+        inner:
+          key:
+           splay: 0
+        index:
+          key:
+           splay: 7
+        middle:
+        ring:
+        pinky:
+          key:
+           splay: 1
+        outer:
+          # ISO style ackslash/pipe or shift on left, maybe hyhen or shift on right?
+          key:
+           splay: 0
+        outer2:
+          # Maybe equals or layer on right?
+          key:
+           asym: right
+           splay: 0
+      rows:
+        sole.padding: 1U
+    thumbs:
+      anchor:
+        ref: bottom_inner_sole
+        shift: [0.5*U, -U]
+      columns:
+        splayed:
+          key:
+           splay: -2
+        tucked:
+          key:
+           splay: 7
+           origin: [0.5*U,-0.5*U]
+           spread: -U
+      rows:
+        sole.padding: 1U
+`,
+};
+
+export default ADux;

--- a/src/examples/curly45.ts
+++ b/src/examples/curly45.ts
@@ -11,11 +11,6 @@ const Curly45: ConfigExample = {
   engine: 4.1.0
   version: 1.0.0
   author: peterjc
-units:
-  # targetting CFX keycaps
-  cx: 16.5
-  cy: 16.5
-  mg: 50
 points:
   mirror:
     ref: top_inner_sole

--- a/src/examples/index.ts
+++ b/src/examples/index.ts
@@ -8,6 +8,7 @@ import Reviung41 from './reviung41';
 import Tiny20 from './tiny20';
 import Alpha from './alpha';
 import Plank from './plank';
+import Curly45 from './curly45';
 
 /**
  * Represents a group of configuration options for the react-select component.
@@ -49,7 +50,7 @@ const simpleExamples = [Absolem, Atreus];
 
 const completeExamples = [Adux, Sweeplike, Reviung41, Tiny20];
 
-const miscExamples = [Wubbo, Alpha, Plank];
+const miscExamples = [Wubbo, Alpha, Plank, Curly45];
 
 /**
  * An array of grouped example configurations to be displayed in the select dropdown.


### PR DESCRIPTION
This is an incomplete concept (no controller or outline), It uses a symmetric katana-like stagger, but the rows curl to finish with the inner column at 22 degrees.

The left side is 21-keys (3x6 core plus two thumbs and an extra key top left which I would use as escape),

The right side is one column wider with 24-keys (3x7 core plus two thumb keys and an extra key top right which I would use as backspace).

This 45-key layout is intended to cover all the core alphabet and punctuation, missing only navigation keys and modifiers.

This lays out the columns right to left (starting with the inner column) using a negative spread. Each row is a different zone to follow matching arcs.

<img width="1157" height="368" alt="Screenshot 2025-10-29 at 14 49 36" src="https://github.com/user-attachments/assets/ee556576-457f-4f1b-a187-db94edbef164" />

The outer columns are near vertical - that could be achieved with a bit more tweaking, but wise to test the actual tollerances first.